### PR TITLE
fix(parsing): process YAML mappings correctly in Application generation

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -394,8 +394,8 @@ pub fn generate_apps_from_app_set(
             (Some(s), _) => {
                 debug!(
                     "Got a list of {} Applications from ApplicationSet in file: {}",
-                    app_set.file_name,
                     s.len()
+                    app_set.file_name,
                 );
                 let apps = s
                     .iter()

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -394,7 +394,7 @@ pub fn generate_apps_from_app_set(
             (Some(s), _) => {
                 debug!(
                     "Got a list of {} Applications from ApplicationSet in file: {}",
-                    s.len()
+                    s.len(),
                     app_set.file_name,
                 );
                 let apps = s
@@ -408,8 +408,8 @@ pub fn generate_apps_from_app_set(
                     .collect::<Vec<ArgoResource>>();
                 debug!(
                     "Generated {} Applications from ApplicationSet in file: {}",
+                    app_set.file_name,
                     apps.len(),
-                    app_set.file_name
                 );
                 patch_applications(
                     &argocd.namespace,


### PR DESCRIPTION
on from ApplicationSets

- Convert YAML mappings to sequences of one element to ensure they are processed correctly.
- Enhance debug logs for better traceability.