### PR TITLE
fix(repo-server-api): pass kustomize.buildOptions from argocd-cm in manifest requests

### DIFF
--- a/.github/workflows/fork-ghcr-build.yml
+++ b/.github/workflows/fork-ghcr-build.yml
@@ -1,0 +1,46 @@
+# Fork-only: build a test image on ghcr.io using the workflow's GITHUB_TOKEN,
+# which is scoped to this repository's packages. Drop this commit before
+# opening the upstream PR.
+name: Fork GHCR build (test image)
+
+on:
+  push:
+    branches:
+      - fix/repo-server-kustomize-build-options
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set env
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          echo "SHA=${SHA}" >> $GITHUB_ENV
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_ENV
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64
+          build-args: |
+            VERSION=kustomize-build-options
+            COMMIT=${{ env.SHA }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+          tags: ghcr.io/${{ github.repository_owner }}/argocd-diff-preview:kustomize-build-options
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/pkg/k8s/manifest.go
+++ b/pkg/k8s/manifest.go
@@ -229,8 +229,8 @@ func (c *Client) GetConfigMaps(namespace string, names ...string) (string, error
 	return string(resultString), nil
 }
 
-// GetConfigMapValue returns the value of a key in a ConfigMap, or "" when the
-// key is absent. e.g. key: "kustomize.buildOptions"
+// GetConfigMapValue returns the value of a key in a ConfigMap, or "" when the key is absent.
+// e.g. key: "kustomize.buildOptions"
 func (c *Client) GetConfigMapValue(namespace string, name string, key string) (string, error) {
 	configMapRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
 	result, err := c.clientSet.Resource(configMapRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})

--- a/pkg/k8s/manifest.go
+++ b/pkg/k8s/manifest.go
@@ -229,6 +229,25 @@ func (c *Client) GetConfigMaps(namespace string, names ...string) (string, error
 	return string(resultString), nil
 }
 
+// GetConfigMapValue returns the value of a key in a ConfigMap, or "" when the
+// key is absent. e.g. key: "kustomize.buildOptions"
+func (c *Client) GetConfigMapValue(namespace string, name string, key string) (string, error) {
+	configMapRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	result, err := c.clientSet.Resource(configMapRes).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get ConfigMap %s: %w", name, err)
+	}
+
+	value, found, err := unstructured.NestedString(result.Object, "data", key)
+	if err != nil {
+		return "", fmt.Errorf("failed to read key %s from ConfigMap %s: %w", key, name, err)
+	}
+	if !found {
+		return "", nil
+	}
+	return value, nil
+}
+
 // get secret value from key. e.g. key: "password"
 func (c *Client) GetSecretValue(namespace string, name string, key string) (string, error) {
 	secretRes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}

--- a/pkg/reposerver/client.go
+++ b/pkg/reposerver/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -33,12 +34,26 @@ const (
 	maxGRPCMessageSize = 100 * 1024 * 1024
 
 	// maxGenerateRetries is the maximum number of attempts for GenerateManifests
-	// before giving up. Retries are triggered by transient gRPC Unavailable errors
-	// (e.g. EOF on the port-forward tunnel under high concurrency).
+	// before giving up. Retries are triggered by transient transport errors
+	// (gRPC Unavailable, or EOF on the port-forward tunnel under high
+	// concurrency).
 	maxGenerateRetries = 5
 	// generateRetryBaseDelay is the initial backoff delay before the first retry.
 	generateRetryBaseDelay = 500 * time.Millisecond
 )
+
+// isRetryableRenderError reports whether a GenerateManifests error is a
+// transient transport failure worth retrying. Besides gRPC Unavailable, a
+// stream.Send on an aborted stream returns a bare io.EOF (the real status is
+// only available via CloseAndRecv), so a wrapped io.EOF is transient too —
+// typical when many concurrent streams share one port-forward tunnel.
+func isRetryableRenderError(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.Unavailable
+}
 
 // Client is a gRPC client for the Argo CD repo server.
 // It manages an optional port-forward to the repo server so that the caller
@@ -249,14 +264,14 @@ func (c *Client) GenerateManifests(ctx context.Context, appDir string, request *
 			return manifests, nil
 		}
 
-		// Only retry on Unavailable (connection/transport errors).
-		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+		// Only retry transient transport errors.
+		if isRetryableRenderError(err) {
 			lastErr = err
 			log.Warn().
 				Str("app", request.AppName).
 				Int("attempt", attempt).
 				Err(err).
-				Msg("⚠️ Transient gRPC Unavailable error from repo server; will retry")
+				Msg("⚠️ Transient transport error from repo server; will retry")
 			continue
 		}
 
@@ -265,6 +280,19 @@ func (c *Client) GenerateManifests(ctx context.Context, appDir string, request *
 	}
 
 	return nil, fmt.Errorf("repo server unavailable after %d attempts: %w", maxGenerateRetries, lastErr)
+}
+
+// abortReason augments a Send error: when a stream has been aborted, Send
+// returns a bare io.EOF and the real status is only surfaced by CloseAndRecv.
+// The io.EOF stays in the wrap chain so isRetryableRenderError still matches.
+func abortReason(stream repoapiclient.RepoServerService_GenerateManifestWithFilesClient, sendErr error) error {
+	if !errors.Is(sendErr, io.EOF) {
+		return sendErr
+	}
+	if _, recvErr := stream.CloseAndRecv(); recvErr != nil && !errors.Is(recvErr, io.EOF) {
+		return fmt.Errorf("%w (stream aborted: %v)", sendErr, recvErr)
+	}
+	return sendErr
 }
 
 // generateManifestsOnce performs a single GenerateManifestWithFiles call.
@@ -299,7 +327,7 @@ func (c *Client) generateManifestsOnce(ctx context.Context, tgzFile *os.File, ch
 			Request: request,
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to send manifest request: %w", err)
+		return nil, fmt.Errorf("failed to send manifest request: %w", abortReason(stream, err))
 	}
 
 	// 2. Send the tarball checksum.
@@ -311,13 +339,13 @@ func (c *Client) generateManifestsOnce(ctx context.Context, tgzFile *os.File, ch
 			},
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to send file metadata: %w", err)
+		return nil, fmt.Errorf("failed to send file metadata: %w", abortReason(stream, err))
 	}
 
 	// 3. Stream the tarball contents in 1 KiB chunks.
 	log.Debug().Str("app", request.AppName).Msg("Streaming tarball to repo server")
 	if err := sendFileChunks(ctx, stream, tgzFile); err != nil {
-		return nil, fmt.Errorf("failed to stream tarball: %w", err)
+		return nil, fmt.Errorf("failed to stream tarball: %w", abortReason(stream, err))
 	}
 
 	// 4. Signal that we're done and receive the rendered manifests.
@@ -387,13 +415,13 @@ func (c *Client) GenerateManifestsRemote(ctx context.Context, request *repoapicl
 			return response.Manifests, nil
 		}
 
-		if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+		if isRetryableRenderError(err) {
 			lastErr = err
 			log.Warn().
 				Str("app", request.AppName).
 				Int("attempt", attempt).
 				Err(err).
-				Msg("⚠️ Transient gRPC Unavailable error from repo server; will retry")
+				Msg("⚠️ Transient transport error from repo server; will retry")
 			continue
 		}
 

--- a/pkg/reposerver/client.go
+++ b/pkg/reposerver/client.go
@@ -33,20 +33,15 @@ const (
 	// maxGRPCMessageSize is the maximum message size for gRPC calls (100 MB).
 	maxGRPCMessageSize = 100 * 1024 * 1024
 
-	// maxGenerateRetries is the maximum number of attempts for GenerateManifests
-	// before giving up. Retries are triggered by transient transport errors
-	// (gRPC Unavailable, or EOF on the port-forward tunnel under high
-	// concurrency).
+	// maxGenerateRetries is the maximum number of attempts for GenerateManifests before giving up.
+	// Retries are triggered by transient transport errors (gRPC Unavailable, or EOF on the port-forward tunnel under high concurrency).
 	maxGenerateRetries = 5
 	// generateRetryBaseDelay is the initial backoff delay before the first retry.
 	generateRetryBaseDelay = 500 * time.Millisecond
 )
 
-// isRetryableRenderError reports whether a GenerateManifests error is a
-// transient transport failure worth retrying. Besides gRPC Unavailable, a
-// stream.Send on an aborted stream returns a bare io.EOF (the real status is
-// only available via CloseAndRecv), so a wrapped io.EOF is transient too —
-// typical when many concurrent streams share one port-forward tunnel.
+// isRetryableRenderError reports whether an error is a transient transport
+// failure worth retrying: gRPC Unavailable, or a bare io.EOF from Send on an aborted stream whose status could not be recovered.
 func isRetryableRenderError(err error) bool {
 	if errors.Is(err, io.EOF) {
 		return true
@@ -282,12 +277,8 @@ func (c *Client) GenerateManifests(ctx context.Context, appDir string, request *
 	return nil, fmt.Errorf("repo server unavailable after %d attempts: %w", maxGenerateRetries, lastErr)
 }
 
-// abortReason resolves a Send error to the stream's real failure: when a
-// stream has been aborted, Send returns a bare io.EOF and the actual status is
-// only surfaced by CloseAndRecv. Preferring that status in the wrap chain lets
-// isRetryableRenderError distinguish transient transport failures (retryable)
-// from deterministic server rejections such as tarball size limits, which
-// must fail fast instead of burning retries.
+// abortReason resolves a Send error to the stream's real failure:
+// Send on an aborted stream returns a bare io.EOF, and the actual status (which decides retryability) is only surfaced by CloseAndRecv.
 func abortReason(stream repoapiclient.RepoServerService_GenerateManifestWithFilesClient, sendErr error) error {
 	if !errors.Is(sendErr, io.EOF) {
 		return sendErr

--- a/pkg/reposerver/client.go
+++ b/pkg/reposerver/client.go
@@ -282,17 +282,21 @@ func (c *Client) GenerateManifests(ctx context.Context, appDir string, request *
 	return nil, fmt.Errorf("repo server unavailable after %d attempts: %w", maxGenerateRetries, lastErr)
 }
 
-// abortReason augments a Send error: when a stream has been aborted, Send
-// returns a bare io.EOF and the real status is only surfaced by CloseAndRecv.
-// The io.EOF stays in the wrap chain so isRetryableRenderError still matches.
+// abortReason resolves a Send error to the stream's real failure: when a
+// stream has been aborted, Send returns a bare io.EOF and the actual status is
+// only surfaced by CloseAndRecv. Preferring that status in the wrap chain lets
+// isRetryableRenderError distinguish transient transport failures (retryable)
+// from deterministic server rejections such as tarball size limits, which
+// must fail fast instead of burning retries.
 func abortReason(stream repoapiclient.RepoServerService_GenerateManifestWithFilesClient, sendErr error) error {
 	if !errors.Is(sendErr, io.EOF) {
 		return sendErr
 	}
-	if _, recvErr := stream.CloseAndRecv(); recvErr != nil && !errors.Is(recvErr, io.EOF) {
-		return fmt.Errorf("%w (stream aborted: %v)", sendErr, recvErr)
+	_, recvErr := stream.CloseAndRecv()
+	if recvErr == nil || errors.Is(recvErr, io.EOF) {
+		return sendErr // no better information; io.EOF stays retryable
 	}
-	return sendErr
+	return fmt.Errorf("stream aborted: %w (send: %v)", recvErr, sendErr)
 }
 
 // generateManifestsOnce performs a single GenerateManifestWithFiles call.

--- a/pkg/reposerver/client_test.go
+++ b/pkg/reposerver/client_test.go
@@ -1,0 +1,49 @@
+package reposerver
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsRetryableRenderError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "grpc unavailable",
+			err:  status.Error(codes.Unavailable, "connection reset"),
+			want: true,
+		},
+		{
+			// stream.Send on an aborted stream returns a bare io.EOF; by the
+			// time the retry loop sees it, it is wrapped twice.
+			name: "wrapped io.EOF from stream send",
+			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("failed to send chunk: %w", io.EOF)),
+			want: true,
+		},
+		{
+			name: "grpc invalid argument",
+			err:  status.Error(codes.InvalidArgument, "bad request"),
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("kustomize build failed"),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetryableRenderError(tc.err); got != tc.want {
+				t.Errorf("isRetryableRenderError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/reposerver/client_test.go
+++ b/pkg/reposerver/client_test.go
@@ -22,8 +22,7 @@ func TestIsRetryableRenderError(t *testing.T) {
 			want: true,
 		},
 		{
-			// stream.Send on an aborted stream returns a bare io.EOF; by the
-			// time the retry loop sees it, it is wrapped twice.
+			// Send on an aborted stream returns a bare io.EOF, wrapped twice by the time the retry loop sees it.
 			name: "wrapped io.EOF from stream send",
 			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("failed to send chunk: %w", io.EOF)),
 			want: true,
@@ -39,15 +38,14 @@ func TestIsRetryableRenderError(t *testing.T) {
 			want: false,
 		},
 		{
-			// abortReason output for a deterministic server rejection: the
-			// real status (Unknown) replaces the bare io.EOF in the chain and
-			// must NOT be retried.
+			// Deterministic server rejection: the real status (Unknown)
+			// replaces the bare io.EOF and must not be retried.
 			name: "wrapped Unknown status from aborted stream",
 			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("stream aborted: %w (send: %v)", status.Error(codes.Unknown, "error receiving tgz file: file exceeded max size of 100000000 bytes"), io.EOF)),
 			want: false,
 		},
 		{
-			// abortReason output for a transient transport abort stays retryable.
+			// Transient transport abort stays retryable.
 			name: "wrapped Unavailable status from aborted stream",
 			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("stream aborted: %w (send: %v)", status.Error(codes.Unavailable, "transport is closing"), io.EOF)),
 			want: true,

--- a/pkg/reposerver/client_test.go
+++ b/pkg/reposerver/client_test.go
@@ -38,6 +38,20 @@ func TestIsRetryableRenderError(t *testing.T) {
 			err:  errors.New("kustomize build failed"),
 			want: false,
 		},
+		{
+			// abortReason output for a deterministic server rejection: the
+			// real status (Unknown) replaces the bare io.EOF in the chain and
+			// must NOT be retried.
+			name: "wrapped Unknown status from aborted stream",
+			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("stream aborted: %w (send: %v)", status.Error(codes.Unknown, "error receiving tgz file: file exceeded max size of 100000000 bytes"), io.EOF)),
+			want: false,
+		},
+		{
+			// abortReason output for a transient transport abort stays retryable.
+			name: "wrapped Unavailable status from aborted stream",
+			err:  fmt.Errorf("failed to stream tarball: %w", fmt.Errorf("stream aborted: %w (send: %v)", status.Error(codes.Unavailable, "transport is closing"), io.EOF)),
+			want: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -172,6 +172,13 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
+	// Mirror Argo CD's API server: the global kustomize build options from
+	// argocd-cm must be passed to the repo server on every request.
+	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
+	if err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
+	}
+
 	// Collect all unique repository URLs referenced by the Applications so that
 	// FetchRepoCreds can enrich them with credentials from repo-creds templates.
 	appRepoURLs := collectRepoURLs(baseApps, targetApps)
@@ -353,7 +360,7 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(remainingTime())*time.Second)
 			defer cancel()
 
-			manifests, childApps, err := renderAppWithChildDiscovery(ctx, repoClient, argocd, item.app, branchFolderByType, branchByType, namespacedScopedResources, creds, &repoSelector, argocd.Namespace, tempFolder, item.depth, kubeVersion, apiVersions, redirectRevisions)
+			manifests, childApps, err := renderAppWithChildDiscovery(ctx, repoClient, argocd, item.app, branchFolderByType, branchByType, namespacedScopedResources, creds, &repoSelector, argocd.Namespace, tempFolder, item.depth, kubeVersion, apiVersions, kustomizeBuildOptions, redirectRevisions)
 			if err != nil {
 				results <- renderResult{err: fmt.Errorf("failed to render app %s: %w", item.app.GetLongName(), err)}
 				return
@@ -443,9 +450,10 @@ func renderAppWithChildDiscovery(
 	depth int,
 	kubeVersion string,
 	apiVersions []string,
+	kustomizeBuildOptions string,
 	redirectRevisions []string,
 ) ([]unstructured.Unstructured, []argoapplication.ArgoResource, error) {
-	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions, helmChartPuller{})
+	allManifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, repoSelector, kubeVersion, apiVersions, kustomizeBuildOptions, helmChartPuller{})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/reposerverextract/appofapps.go
+++ b/pkg/reposerverextract/appofapps.go
@@ -172,8 +172,8 @@ func RenderApplicationsFromBothBranchesWithAppOfApps(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
-	// Mirror Argo CD's API server: the global kustomize build options from
-	// argocd-cm must be passed to the repo server on every request.
+	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
+	// the repo server never reads the ConfigMap.
 	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
 	if err != nil {
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -103,11 +103,8 @@ func RenderApplicationsFromBothBranches(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
-	// Argo CD's API server injects the global kustomize build options from
-	// argocd-cm into every repo-server request; mirror that here, because the
-	// repo server never reads the ConfigMap itself. Without this, options like
-	// --load-restrictor LoadRestrictionsNone are silently dropped and
-	// kustomizations referencing files outside their directory fail to render.
+	// Mirror Argo CD's API server: pass the global kustomize build options from argocd-cm on every request;
+	// the repo server never reads the ConfigMap.
 	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
 	if err != nil {
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
@@ -738,12 +735,20 @@ func buildManifestRequestForSource(
 		}
 	}
 
-	// Copy the content source directory into the temp tree.
+	// Kustomize sources can reference files outside their own directory, so
+	// stage the whole branch folder for them (as the no-refs fast path does).
 	srcContentDir := filepath.Join(branchFolder, primarySource.Path)
-	dstContentDir := filepath.Join(tempDir, primarySource.Path)
-	if err := copyDir(srcContentDir, dstContentDir); err != nil {
-		cleanup()
-		return nil, "", nil, fmt.Errorf("failed to copy content source dir %q: %w", srcContentDir, err)
+	if isKustomizeSource(srcContentDir) {
+		if err := copyDir(branchFolder, tempDir); err != nil {
+			cleanup()
+			return nil, "", nil, fmt.Errorf("failed to copy branch folder %q: %w", branchFolder, err)
+		}
+	} else {
+		dstContentDir := filepath.Join(tempDir, primarySource.Path)
+		if err := copyDir(srcContentDir, dstContentDir); err != nil {
+			cleanup()
+			return nil, "", nil, fmt.Errorf("failed to copy content source dir %q: %w", srcContentDir, err)
+		}
 	}
 
 	// Copy each ref source into <tempDir>/.refs/<refName>/.
@@ -1030,6 +1035,10 @@ func copyDir(src, dst string) error {
 	return filepath.Walk(src, func(srcPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		// Git metadata is never part of rendered content and can be huge.
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
 		}
 		rel, err := filepath.Rel(src, srcPath)
 		if err != nil {

--- a/pkg/reposerverextract/extract.go
+++ b/pkg/reposerverextract/extract.go
@@ -103,6 +103,19 @@ func RenderApplicationsFromBothBranches(
 		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get server version: %w", err)
 	}
 
+	// Argo CD's API server injects the global kustomize build options from
+	// argocd-cm into every repo-server request; mirror that here, because the
+	// repo server never reads the ConfigMap itself. Without this, options like
+	// --load-restrictor LoadRestrictionsNone are silently dropped and
+	// kustomizations referencing files outside their directory fail to render.
+	kustomizeBuildOptions, err := argocd.K8sClient.GetConfigMapValue(argocd.Namespace, "argocd-cm", "kustomize.buildOptions")
+	if err != nil {
+		return nil, nil, time.Since(startTime), fmt.Errorf("failed to get kustomize build options from argocd-cm: %w", err)
+	}
+	if kustomizeBuildOptions != "" {
+		log.Info().Msgf("🔧 Using kustomize build options from argocd-cm: %s", kustomizeBuildOptions)
+	}
+
 	// Collect all unique repository URLs referenced by the Applications so that
 	// FetchRepoCreds can enrich them with credentials from repo-creds templates.
 	appRepoURLs := collectRepoURLs(baseApps, targetApps)
@@ -182,7 +195,7 @@ func RenderApplicationsFromBothBranches(
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(remainingTime())*time.Second)
 			defer cancel()
 
-			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions, helmChartPuller{})
+			manifests, err := renderApp(ctx, repoClient, app, branchFolderByType, namespacedScopedResources, creds, &repoSelector, kubeVersion, apiVersions, kustomizeBuildOptions, helmChartPuller{})
 			if err != nil {
 				results <- result{err: fmt.Errorf("failed to render app %s: %w", app.GetLongName(), err)}
 				return
@@ -259,6 +272,7 @@ func renderApp(
 	repoSelector *repository.Selector,
 	kubeVersion string,
 	apiVersions []string,
+	kustomizeBuildOptions string,
 	puller chartPuller,
 ) ([]unstructured.Unstructured, error) {
 	branchFolder, ok := branchFolderByType[app.Branch]
@@ -282,10 +296,11 @@ func renderApp(
 			branchFolder,
 			creds,
 			manifestRequestRenderContext{
-				repoSelector: repoSelector,
-				kubeVersion:  kubeVersion,
-				apiVersions:  apiVersions,
-				puller:       puller,
+				repoSelector:          repoSelector,
+				kubeVersion:           kubeVersion,
+				apiVersions:           apiVersions,
+				kustomizeBuildOptions: kustomizeBuildOptions,
+				puller:                puller,
 			},
 		)
 		if err != nil {
@@ -524,6 +539,10 @@ type manifestRequestRenderContext struct {
 	repoSelector *repository.Selector
 	kubeVersion  string
 	apiVersions  []string
+	// kustomizeBuildOptions holds the global `kustomize.buildOptions` value
+	// from argocd-cm. Argo CD's API server passes it to the repo server on
+	// every request; the repo server never reads the ConfigMap itself.
+	kustomizeBuildOptions string
 	// puller fetches remote Helm charts so they can be streamed to the repo
 	// server together with same-repo $ref value files. When nil, remote charts
 	// with ref sources fall back to the unary GenerateManifest RPC.
@@ -552,7 +571,7 @@ func buildManifestRequestForSource(
 	namespace, _, _ := unstructured.NestedString(obj, append(specPath, "destination", "namespace")...)
 
 	newManifestRequest := func(source *v1alpha1.ApplicationSource) *repoapiclient.ManifestRequest {
-		return &repoapiclient.ManifestRequest{
+		request := &repoapiclient.ManifestRequest{
 			Repo:               creds.GetRepo(source.RepoURL),
 			Repos:              creds.HelmRepos(source),
 			HelmRepoCreds:      creds.HelmRepoCreds(source),
@@ -570,6 +589,12 @@ func buildManifestRequestForSource(
 			ProjectName:        "default",
 			ProjectSourceRepos: []string{"*"},
 		}
+		if renderContext.kustomizeBuildOptions != "" {
+			request.KustomizeOptions = &v1alpha1.KustomizeOptions{
+				BuildOptions: renderContext.kustomizeBuildOptions,
+			}
+		}
+		return request
 	}
 
 	// Fast path: no ref sources.

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -179,10 +179,9 @@ spec:
 	assertDefaultProjectFields(t, req)
 }
 
-// Global kustomize build options from argocd-cm (e.g. --load-restrictor
-// LoadRestrictionsNone) must reach the repo server on every request, exactly
-// like Argo CD's API server passes them; the repo server never reads the
-// ConfigMap itself.
+// Global kustomize build options from argocd-cm (e.g. --load-restrictor LoadRestrictionsNone)
+// must reach the repo server on every request, exactly like Argo CD's API server passes them;
+// the repo server never reads the ConfigMap itself.
 func TestBuildManifestRequest_KustomizeBuildOptions(t *testing.T) {
 	branchFolder := makeBranchFolder(t, "apps/my-app")
 
@@ -256,7 +255,8 @@ spec:
 	require.Len(t, contentSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, "")})
+		repoSelector: testRepoSelector(t, ""),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -325,7 +325,8 @@ spec:
 	require.Len(t, refSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, "")})
+		repoSelector: testRepoSelector(t, ""),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -504,7 +505,8 @@ spec:
 	require.Len(t, refSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, "")})
+		repoSelector: testRepoSelector(t, ""),
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, streamDir, "local chart with refs must stream a temp dir")
 	defer cleanup()
@@ -528,6 +530,54 @@ spec:
 	_, statErr := os.Stat(absValueFile)
 	assert.NoError(t, statErr, "rewritten value file path %q should exist on disk", absValueFile)
 	assertDefaultProjectFields(t, req)
+}
+
+// Multi-source: a kustomize content source referencing files outside its own directory must stage the whole branch folder
+// (as the no-refs fast path does), or the escaping reference fails with "no such file or directory".
+func TestBuildManifestRequest_MultiSource_Kustomize_WithRef_StagesBranchRoot(t *testing.T) {
+	branchFolder := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "clusters", "dev", "my-app"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(branchFolder, "clusters", "dev", "my-app", "kustomization.yaml"),
+		[]byte("resources:\n  - ../../../base/my-app\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(branchFolder, "base", "my-app"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(branchFolder, "base", "my-app", "kustomization.yaml"),
+		[]byte("resources: []\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(branchFolder, "values.yaml"), []byte("a: 1\n"), 0o644))
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app-dev
+spec:
+  destination:
+    namespace: production
+  sources:
+    - repoURL: https://github.com/org/repo.git
+      ref: values
+      targetRevision: HEAD
+    - repoURL: https://github.com/org/repo.git
+      path: clusters/dev/my-app
+      targetRevision: HEAD
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+	require.Len(t, refSources, 1)
+
+	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
+		repoSelector: testRepoSelector(t, ""),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, streamDir)
+	defer cleanup()
+
+	assert.Equal(t, "clusters/dev/my-app", req.ApplicationSource.Path)
+	_, statErr := os.Stat(filepath.Join(streamDir, "base", "my-app", "kustomization.yaml"))
+	assert.NoError(t, statErr, "files referenced outside the kustomize source dir must be staged")
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -616,7 +666,8 @@ spec:
 	require.NotEmpty(t, chartSource.Chart, "should find the chart content source")
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, chartSource, refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, "")})
+		repoSelector: testRepoSelector(t, ""),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -677,7 +728,8 @@ spec:
 	require.Len(t, refSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, "")})
+		repoSelector: testRepoSelector(t, ""),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -762,7 +814,8 @@ spec:
 	// Capture requests so we can verify per-source paths without duplicate calls.
 	for i, cs := range contentSources {
 		req, streamDir, cleanup, buildErr := buildManifestRequestForSource(app, cs, refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-			repoSelector: testRepoSelector(t, "")})
+			repoSelector: testRepoSelector(t, ""),
+		})
 		require.NoError(t, buildErr, "content source %d should not error", i)
 		if cleanup != nil {
 			defer cleanup()
@@ -819,7 +872,8 @@ spec:
 	require.Empty(t, refSources)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, prRepo)})
+		repoSelector: testRepoSelector(t, prRepo),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -870,7 +924,8 @@ spec:
 	require.Len(t, contentSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, prRepo)})
+		repoSelector: testRepoSelector(t, prRepo),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -912,7 +967,8 @@ spec:
 	require.Len(t, refSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, prRepo)})
+		repoSelector: testRepoSelector(t, prRepo),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()
@@ -1068,7 +1124,8 @@ spec:
 	require.Len(t, contentSources, 1)
 
 	req, streamDir, cleanup, err := buildManifestRequestForSource(app, contentSources[0], refSources, hasMultipleSources, branchFolder, nil, manifestRequestRenderContext{
-		repoSelector: testRepoSelector(t, prRepo)})
+		repoSelector: testRepoSelector(t, prRepo),
+	})
 	require.NoError(t, err)
 	if cleanup != nil {
 		defer cleanup()

--- a/pkg/reposerverextract/extract_test.go
+++ b/pkg/reposerverextract/extract_test.go
@@ -175,7 +175,57 @@ spec:
 	assert.Equal(t, kubeVersion, req.KubeVersion)
 	assert.Equal(t, apiVersions, req.ApiVersions)
 	assert.Nil(t, req.RefSources)
+	assert.Nil(t, req.KustomizeOptions, "no build options configured: field must stay unset")
 	assertDefaultProjectFields(t, req)
+}
+
+// Global kustomize build options from argocd-cm (e.g. --load-restrictor
+// LoadRestrictionsNone) must reach the repo server on every request, exactly
+// like Argo CD's API server passes them; the repo server never reads the
+// ConfigMap itself.
+func TestBuildManifestRequest_KustomizeBuildOptions(t *testing.T) {
+	branchFolder := makeBranchFolder(t, "apps/my-app")
+
+	app := makeApp(t, `
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  destination:
+    namespace: production
+  source:
+    repoURL: https://github.com/org/repo.git
+    path: apps/my-app
+    targetRevision: HEAD
+`)
+
+	contentSources, refSources, hasMultipleSources, err := splitSources(app)
+	require.NoError(t, err)
+	require.Len(t, contentSources, 1)
+
+	buildOptions := "--enable-alpha-plugins --enable-exec --load-restrictor LoadRestrictionsNone"
+	req, _, cleanup, err := buildManifestRequestForSource(
+		app,
+		contentSources[0],
+		refSources,
+		hasMultipleSources,
+		branchFolder,
+		nil,
+		manifestRequestRenderContext{
+			repoSelector:          testRepoSelector(t, ""),
+			kubeVersion:           "v1.30.1",
+			apiVersions:           []string{"apps/v1", "v1"},
+			kustomizeBuildOptions: buildOptions,
+		},
+	)
+	require.NoError(t, err)
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	require.NotNil(t, req.KustomizeOptions)
+	assert.Equal(t, buildOptions, req.KustomizeOptions.BuildOptions)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## repo-server-api render fixes

Three fixes to `--render-method repo-server-api`, found rendering a ~1700-app monorepo. Each is a separate commit, cherry-picked into its own upstream PR; the fork CI image-build commit stays here.

### 1. Pass `kustomize.buildOptions` to the repo server
Argo CD's API server injects the global kustomize build options from `argocd-cm` into every repo-server request; this render method built its requests without them, silently dropping options like `--load-restrictor LoadRestrictionsNone`. 35 load-restriction failures → 0.

### 2. Retry + diagnose aborted streams
`Send` on an aborted stream returns a bare `io.EOF`; the retry loop only matched `codes.Unavailable`, so the most common transient failure was never retried — and the real abort reason was invisible. Now `CloseAndRecv` surfaces the actual status: transient aborts retry, deterministic rejections fail fast with a readable cause (259 opaque `EOF`s turned out to be tarball-size limits).

### 3. Stage escaping kustomize references
Multi-source apps with a kustomize content source staged only the source dir + `.refs/`, so `../../` references broke. Stage the whole branch folder instead, mirroring the no-refs fast path. 6 failures → 0. Trades a per-app tree copy for correctness; only hit by kustomize sources with ref sources.

### Validation
Unit tests per fix, plus a full render of a large private monorepo (1700+ apps) successful with previously missed diffs.